### PR TITLE
Update the component so it works with GOV.UK Components 3.0.5

### DIFF
--- a/app/components/dfe/autocomplete/view.html.erb
+++ b/app/components/dfe/autocomplete/view.html.erb
@@ -1,3 +1,3 @@
-<%= tag.div(class: classes, **html_attributes) do %>
+<%= tag.div(**html_attributes) do %>
   <%= form_field.html_safe %>
 <% end %>

--- a/app/components/dfe/autocomplete/view.rb
+++ b/app/components/dfe/autocomplete/view.rb
@@ -6,20 +6,17 @@ module DfE
         @attribute_value = form.object.send(attribute_name)
         @attribute_name = attribute_name
         @form_field = form_field
-        super(classes: classes, html_attributes: default_html_attributes.merge(html_attributes))
+        super(classes: classes, html_attributes: html_attributes)
       end
 
       private
 
       attr_accessor :form_field, :attribute_name
 
-      def default_classes
-        %w[app-!-autocomplete--max-width-two-thirds suggestions]
-      end
-
-      def default_html_attributes
+      def default_attributes
         {
           id: attribute_name.to_s,
+          'class' => %w[app-!-autocomplete--max-width-two-thirds suggestions],
           'data-module' => 'app-dfe-autocomplete',
           'data-default-value' => (@raw_attribute_value || @attribute_value).to_s
         }

--- a/spec/components/dfe/autocomplete/view_spec.rb
+++ b/spec/components/dfe/autocomplete/view_spec.rb
@@ -65,7 +65,7 @@ module DfE
         end
 
         it 'create empty default value' do
-          expect(component).to have_selector('[data-default-value=""]')
+          expect(component).to have_selector('[data-module="app-dfe-autocomplete"]')
         end
       end
 


### PR DESCRIPTION
In govuk-components 3.0.5 the mechanism used to set default classes and attributes changed. Now instead of a `classes` array and a `html_attributes` hash, there's just a `html_attributes` hash that allows classes to be passed in under the `class` key. This is possible because under the hood the govuk-components gem uses [html-attributes-utils](https://github.com/DFE-Digital/html-attributes-utils) which makes it easier to cleanly merge deep hashes without losing the default values.
