### PR TITLE
Add 'with' to list of stop words

### DIFF
--- a/src/sort/stop_words.js
+++ b/src/sort/stop_words.js
@@ -1,4 +1,4 @@
-const stopWords = ['the', 'of', 'in', 'and', 'at', '&']
+const stopWords = ['the', 'of', 'in', 'and', 'at', '&', 'with']
 
 const removeStopWords = (text) => {
   const isAllStopWords = text.trim().split(' ').every((word) => stopWords.includes(word))


### PR DESCRIPTION
With is a common word we see in degree subjects. Adding it to this list will mean a user searching for `Psychology with criminology` will still see the suggestion for `Psychology and criminology`.