### PR TITLE
Pass in all libraryOptions to autocomplete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /spec/dummy/storage/
 /spec/dummy/tmp/
 Gemfile.lock
+node_modules

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Supported options:
 * `minLength`: The minimum number of characters that should be entered before the autocomplete will attempt to suggest options. When the query length is under this, the aria status region will also provide helpful text to the user informing them they should type in more.
 * `rawAttribute`: the second parameter that will be sent when user submits the form. This is useful when the user types free text instead of choosing any element in the collection.
 
+Plus all the other options from the upstream autocomplete: https://github.com/alphagov/accessible-autocomplete#api-documentation
+
 ## Stylesheet
 
 You need to import it using Sass:

--- a/src/dfe-autocomplete.js
+++ b/src/dfe-autocomplete.js
@@ -1,5 +1,4 @@
 import accessibleAutocomplete from 'accessible-autocomplete'
-import { nodeListForEach } from 'govuk-frontend/govuk/common'
 import sort from './sort'
 
 let minLength;

--- a/src/dfe-autocomplete.js
+++ b/src/dfe-autocomplete.js
@@ -68,7 +68,8 @@ export const setupAccessibleAutoComplete = (component, libraryOptions = {}) => {
       tracker.sendTrackingEvent(val, selectEl.name)
       const selectedOption = [].filter.call(selectOptions, option => (option.textContent || option.innerText) === val)[0]
       if (selectedOption) selectedOption.selected = true
-    }
+    },
+    ...libraryOptions
   })
 
   if (inError) {


### PR DESCRIPTION
We should allow users to override any of the default options for the autocomplete.

Plus some misc cleanup tasks, see individual commits.