### PR TITLE
Allow customising the element value

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,13 @@ Then we can output the HTML required for the JS to work using the gem component
 ```
 
 The helper `dfe_autocomplete_options` assumes that the elements in the
-collection respond to the method `name` and if the element respond to `synonyms`
-that will be included in the synonyms list automatically. If you want to pass
-other methods that are synonyms you can include as the example above
-`suggestion_synonyms match_synonyms`. If you need to append any data to the
-results you can use the `append` option. There is also the boost option.
+collection respond to the method `name`. If the element responds to `value`
+that will be used as the value of the `<option>` HTML element. If the
+element responds to `synonyms` that will be included in the synonyms list
+automatically. If you want to pass  other methods that are synonyms you can
+include as the example above `suggestion_synonyms match_synonyms`. If you
+need to append any data to the results you can use the `append` option.
+There is also the boost option.
 
 ## Javascript
 

--- a/app/helpers/dfe/autocomplete/application_helper.rb
+++ b/app/helpers/dfe/autocomplete/application_helper.rb
@@ -11,7 +11,10 @@ module DfE
           append_data = record.send(append) if append.present?
           data['data-append'] = append_data && tag.strong("(#{append_data})")
 
-          [record.name, record.name, data]
+          name = record.name
+          value = record.try(:value).presence || name
+
+          [name, value, data]
         end.unshift([nil, nil, nil])
       end
 

--- a/spec/helpers/dfe/autocomplete/application_helper_spec.rb
+++ b/spec/helpers/dfe/autocomplete/application_helper_spec.rb
@@ -1,5 +1,21 @@
 RSpec.describe DfE::Autocomplete::ApplicationHelper, type: :helper do
   describe '#dfe_autocomplete_options' do
+    context 'when records have values' do
+      it 'uses the values instead of the name' do
+        records = [
+          double(name: 'Bachelor of Arts Economics', value: "baecon")
+        ]
+        expect(helper.dfe_autocomplete_options(records)).to eq([
+          [nil, nil, nil],
+          [
+            'Bachelor of Arts Economics',
+            'baecon',
+            { 'data-append' => nil, 'data-boost' => 1.5, 'data-synonyms' => '' }
+          ]
+        ])
+      end
+    end
+
     context 'when appending values into the suggestions' do
       it 'adds the data append attribute' do
         records = [


### PR DESCRIPTION
This change allows the value of `<option>` to be customised rather than using the `name` of the element, meaning that for cases where we want to use the autocomplete, but want an identifier passed to the controller (rather than a human-readable string) so it can be stored as a reference.