### PR TITLE
Remove govuk-if-ie8 sass mixin and styling

### DIFF
--- a/app/assets/stylesheets/dfe/autocomplete/style.scss
+++ b/app/assets/stylesheets/dfe/autocomplete/style.scss
@@ -76,10 +76,6 @@
   outline: $govuk-focus-width solid $govuk-focus-colour;
   outline-offset: 0;
   box-shadow: inset 0 0 0 $govuk-border-width-form-element;
-
-  @include govuk-if-ie8 {
-    border-width: $govuk-border-width-form-element * 2;
-  }
 }
 
 .autocomplete__input--show-all-values {

--- a/src/dfe-autocomplete.scss
+++ b/src/dfe-autocomplete.scss
@@ -47,10 +47,6 @@
     outline: $govuk-focus-width solid $govuk-focus-colour;
     outline-offset: 0;
     box-shadow: inset 0 0 0 $govuk-border-width-form-element;
-
-    @include govuk-if-ie8 {
-      border-width: $govuk-border-width-form-element * 2;
-    }
   }
 
   .autocomplete__input--show-all-values {


### PR DESCRIPTION
This should fix a deprecation warning from govuk-frontend by removing the ie8 specific styling.

```
WARNING: The govuk-if-ie8 mixin is deprecated and will be removed in v5.0. To silence this warning, update $govuk-suppressed-warnings with key: "ie8"
    node_modules/govuk-frontend/govuk/settings/_warnings.scss 49:5  -warning()
    node_modules/govuk-frontend/govuk/tools/_ie8.scss 37:3          govuk-if-ie8()
    node_modules/dfe-autocomplete/src/dfe-autocomplete.scss 51:5    @import
    app/frontend/entrypoints/application.scss 7:9                   root stylesheet
```
