### PR TITLE
Update build script name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
       - run: npm ci
-      - run: npm run build
+      - run: npm run compile
       - name: Show any unstaged changes in dist
         run: git diff dist
       - name: Throw if dist is not committed

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The helper `dfe_autocomplete_options` assumes that the elements in the
 collection respond to the method `name`. If the element responds to `value`
 that will be used as the value of the `<option>` HTML element. If the
 element responds to `synonyms` that will be included in the synonyms list
-automatically. If you want to pass  other methods that are synonyms you can
+automatically. If you want to pass other methods that are synonyms you can
 include as the example above `suggestion_synonyms match_synonyms`. If you
 need to append any data to the results you can use the `append` option.
 There is also the boost option.
@@ -155,7 +155,7 @@ You need to import it using Sass:
 
 ## Contributing
 
-Run the `npm run build` and commit the resulting `dist` folder:
+Run the `npm run compile` and commit the resulting `dist` folder:
 
 ```bash
 npm run build

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "scripts": {
     "test": "test",
-    "build:js": "cross-env NODE_ENV=production webpack --progress --display-modules",
-    "build": "npm run -s 'build:js'",
+    "compile:js": "cross-env NODE_ENV=production webpack --progress --display-modules",
+    "compile": "npm run -s 'compile:js'",
     "standard": "standard"
   },
   "repository": {


### PR DESCRIPTION
This commit updates the name of the build script so that NPM does not automatically build the package when a consumer runs `npm install`.

See the NPM docs for information on why this happens: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#git-urls-as-dependencies

Fixes #17 