### PR TITLE
Change suggestions visual cue

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ You need to import it using Sass:
 @import "dfe-autocomplete/src/dfe-autocomplete";
 ```
 
+If your frontend build supports directly importing Sass from node_modules, you can import it from the root folder without specifying the path:
+
+```scss
+@import "dfe-autocomplete";
+```
+
 ## Contributing
 
 Run the `npm run compile` and commit the resulting `dist` folder:

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "DfE Autocomplete built on top of accessible autocomplete lib",
   "main": "dist/dfe-autocomplete.min.js",
   "style": "dist/dfe-autocomplete.min.css",
+  "sass": "src/dfe-autocomplete.scss",
   "directories": {
     "lib": "lib"
   },

--- a/src/dfe-autocomplete.scss
+++ b/src/dfe-autocomplete.scss
@@ -1,19 +1,7 @@
 @import "accessible-autocomplete/src/autocomplete";
 
 // Overrides
-  body .suggestions .autocomplete__menu {
-    top: 20px;
-    border-top: 2px solid black;
-  }
 
-  body .suggestions .autocomplete__wrapper ul::before {
-    content: 'Suggestions';
-    padding: 4px 8px;
-    border-bottom: 2px solid black;
-    background-color: #f3f2f1;
-    width: 100%;
-    display: block;
-  }
 
 // Regular styles from source
 .suggestions {

--- a/src/dfe-autocomplete.scss
+++ b/src/dfe-autocomplete.scss
@@ -1,7 +1,29 @@
 @import "accessible-autocomplete/src/autocomplete";
 
 // Overrides
+body .suggestions {
+  .autocomplete__input--focused[aria-expanded="true"] {
+    border-bottom: 0;
+  }
 
+  .autocomplete__input.autocomplete__input--focused[aria-expanded="true"] {
+    box-shadow: inset 2px 2px 0 0, inset -2px 0 0 0;
+  }
+
+  .autocomplete__input ~ .autocomplete__menu:before {
+    content: "";
+    display: block;
+    background-color: #0b0c0c;
+    height: 1px;
+    width: calc(100% - 20px);
+    margin: 0 0 0 10px;
+  }
+
+  .autocomplete__menu {
+    margin: 0 0 0 2px;
+    width: calc(100% - 8px);
+  }
+}
 
 // Regular styles from source
 .suggestions {


### PR DESCRIPTION
Changes the way the component displays the suggestions for a given input.

Previously there was a gap between the input and the suggestions, and text saying 'Suggestions' in a ::before pseudo-element.

This PR removes the pseudo-element and the gap between the input and suggestions. Instead, when there are suggestions and the input is focused, the bottom border of the input will appear to shrink so that it's apparent to users that there is additional content underneath the input.

This should improve the experience for users of screen magnification software, who will now be more likely to notice the suggestions when fully zoomed into the input.

Most of the code here comes from a [near-identical change](https://github.com/alphagov/accessible-autocomplete/pull/753) which was proposed for the accessible-autocomplete repo.

Fixes #21 