### PR TITLE
Remove hint border

### DIFF
--- a/src/dfe-autocomplete.scss
+++ b/src/dfe-autocomplete.scss
@@ -2,7 +2,8 @@
 
 // Overrides
 body .suggestions {
-  .autocomplete__input--focused[aria-expanded="true"] {
+  .autocomplete__input--focused[aria-expanded="true"],
+  .autocomplete__hint {
     border-bottom: 0;
   }
 


### PR DESCRIPTION
In #23 we changed the UI for displaying suggestions to remove the border under the search box.

This causes an issue where if the autocomplete has `autoselect: true` and the search text matches a result, the hint that appears in the text box includes a border:

![Screenshot 2025-02-11 at 16 38 40](https://github.com/user-attachments/assets/1b9eb0e8-637b-4b4a-b38a-49d1319dfdc4)

This unwanted border is coming from the `.autocomplete__hint` class. This PR removes the border from the bottom of this element so that the hint appears as expected:

![Screenshot 2025-02-11 at 16 40 11](https://github.com/user-attachments/assets/9e17f1d2-0f4b-46b8-a0ea-25eb70579b70)
