### PR TITLE
Use new Sass module system

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,16 +158,16 @@ with `[data-module="app-dfe-autocomplete"]`.
 Example (using Stimulus):
 
 ```javascript
-  import { Controller } from '@hotwired/stimulus'
-  import { dfeAutocompleteField } from 'dfe-autocomplete';
+import { Controller } from "@hotwired/stimulus";
+import { dfeAutocompleteField } from "dfe-autocomplete";
 
-  export default class extends Controller {
-    connect() {
-      dfeAutocompleteField(this.element, {
-        minLength: 2,
-      })
-    }
+export default class extends Controller {
+  connect() {
+    dfeAutocompleteField(this.element, {
+      minLength: 2,
+    });
   }
+}
 ```
 
 ## Stylesheet
@@ -175,13 +175,13 @@ Example (using Stimulus):
 You need to import it using Sass:
 
 ```scss
-@import "dfe-autocomplete/src/dfe-autocomplete";
+@forward "dfe-autocomplete/src/dfe-autocomplete";
 ```
 
 If your frontend build supports directly importing Sass from node_modules, you can import it from the root folder without specifying the path:
 
 ```scss
-@import "dfe-autocomplete";
+@forward "dfe-autocomplete";
 ```
 
 ## Contributing

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "accessible-autocomplete": "^3.0.1"
+        "accessible-autocomplete": "^3.0.1",
+        "govuk-frontend": "^5.8.0"
       },
       "devDependencies": {
         "@babel/core": "^7.26.0",
@@ -3250,6 +3251,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/govuk-frontend": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.8.0.tgz",
+      "integrity": "sha512-6l3f/YhDUCWjpmSW3CL95Hg8B+ZLzTf2WYo25ZtCs2Lb8UIzxxxFI8LxG7Ey/z04UuPhUunqFhTwSkQyJ69XbQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.2.0"
       }
     },
     "node_modules/graceful-fs": {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   ],
   "devDependencies": {
     "@babel/core": "^7.26.0",
-    "@babel/plugin-transform-class-properties": "^7.25.9",
     "@babel/plugin-proposal-decorators": "^7.25.9",
+    "@babel/plugin-transform-class-properties": "^7.25.9",
     "@babel/plugin-transform-member-expression-literals": "^7.25.9",
     "@babel/plugin-transform-modules-commonjs": "^7.25.9",
     "@babel/plugin-transform-property-literals": "^7.25.9",
@@ -60,6 +60,7 @@
     "parser": "babel-eslint"
   },
   "dependencies": {
-    "accessible-autocomplete": "^3.0.1"
+    "accessible-autocomplete": "^3.0.1",
+    "govuk-frontend": "^5.8.0"
   }
 }

--- a/src/dfe-autocomplete.scss
+++ b/src/dfe-autocomplete.scss
@@ -1,5 +1,5 @@
 @use "govuk-frontend" as *;
-@import "accessible-autocomplete/src/autocomplete";
+@forward "accessible-autocomplete/src/autocomplete";
 
 // Overrides
 body .suggestions {

--- a/src/dfe-autocomplete.scss
+++ b/src/dfe-autocomplete.scss
@@ -1,3 +1,4 @@
+@use "govuk-frontend" as *;
 @import "accessible-autocomplete/src/autocomplete";
 
 // Overrides


### PR DESCRIPTION
Switches from the legacy Sass import syntax (`@import`) to the modern one (`@use`/`@forward`).

The legacy import is deprecated and will be removed in the next major Sass version.

Advantages:
- makes the dependency on govuk-frontend explicit
- removes uses of the deprecated Sass command
- makes it easier users of this package to remove legacy imports in their own 

Disadvantages:
- Users of this package who aren't using the new Sass import syntax will be importing two copies of `govuk-frontend`, so their bundles will increase in size.