### PR TITLE
Update package.json version to v0.2.1

### DIFF
--- a/lib/dfe/autocomplete/version.rb
+++ b/lib/dfe/autocomplete/version.rb
@@ -1,5 +1,5 @@
 module DfE
   module Autocomplete
-    VERSION = '0.2.0'.freeze
+    VERSION = '0.2.1'.freeze
   end
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dfe-autocomplete",
-  "version": "0.0.1",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dfe-autocomplete",
-      "version": "0.0.1",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "accessible-autocomplete": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dfe-autocomplete",
-  "version": "0.0.1",
+  "version": "0.2.1",
   "description": "DfE Autocomplete built on top of accessible autocomplete lib",
   "main": "dist/dfe-autocomplete.min.js",
   "style": "dist/dfe-autocomplete.min.css",


### PR DESCRIPTION
Since v0.2.0 is already tagged in git, we can release v0.2.1 as the properly versioned tag.