### PR TITLE
Bump version to v1.0.0

### DIFF
--- a/lib/dfe/autocomplete/version.rb
+++ b/lib/dfe/autocomplete/version.rb
@@ -1,5 +1,5 @@
 module DfE
   module Autocomplete
-    VERSION = '0.2.1'.freeze
+    VERSION = '1.0.0'.freeze
   end
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dfe-autocomplete",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dfe-autocomplete",
-      "version": "0.2.1",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "accessible-autocomplete": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dfe-autocomplete",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "description": "DfE Autocomplete built on top of accessible autocomplete lib",
   "main": "dist/dfe-autocomplete.min.js",
   "style": "dist/dfe-autocomplete.min.css",


### PR DESCRIPTION
Sync package.json, package-lock.json and the Ruby gem version file to 1.0.0 for the v1.0.0 release documented in CHANGELOG.md.